### PR TITLE
Restrict ORM index key length to a maximum of 191 characters

### DIFF
--- a/src/Entity/DoctrineMaps/CodeFoundation.FlowConfig.Entity.ConfigItem.orm.xml
+++ b/src/Entity/DoctrineMaps/CodeFoundation.FlowConfig.Entity.ConfigItem.orm.xml
@@ -9,7 +9,13 @@
             <index name="key_idx" columns="key"/>
         </indexes>
 
-        <id name="key" type="string"><generator strategy="NONE"/></id>
+        <!--
+            Indexed column is restricted to a maximum length of 191 characters because MySQL Innodb engine (with
+            utf8mb4 encoding) would not allow index key prefix length of more than 767 bytes.
+
+            Refer https://dev.mysql.com/doc/refman/5.6/en/innodb-restrictions.html
+        -->
+        <id name="key" type="string" length="64"><generator strategy="NONE"/></id>
         <field name="value" column="value" type="string" nullable="true" unique="false" />
 
     </entity>

--- a/src/Entity/DoctrineMaps/CodeFoundation.FlowConfig.Entity.EntityConfigItem.orm.xml
+++ b/src/Entity/DoctrineMaps/CodeFoundation.FlowConfig.Entity.EntityConfigItem.orm.xml
@@ -9,9 +9,15 @@
             <index name="keys_combo_idx" columns="key,entity_type,entity_id"/>
         </indexes>
 
-        <id name="key" column="key" type="string"><generator strategy="NONE"/></id>
-        <id name="entityType" column="entity_type" type="string"><generator strategy="NONE"/></id>
-        <id name="entityId" column="entity_id" type="string"><generator strategy="NONE"/></id>
+        <!--
+            Indexed column is restricted to a maximum length of 191 characters because MySQL Innodb engine (with
+            utf8mb4 encoding) would not allow index key prefix length of more than 767 bytes.
+
+            Refer https://dev.mysql.com/doc/refman/5.6/en/innodb-restrictions.html
+        -->
+        <id name="key" column="key" type="string" length="64"><generator strategy="NONE"/></id>
+        <id name="entityType" column="entity_type" type="string" length="191"><generator strategy="NONE"/></id>
+        <id name="entityId" column="entity_id" type="string" length="64"><generator strategy="NONE"/></id>
         <field name="value" column="value" type="string" nullable="true" unique="false" />
 
     </entity>


### PR DESCRIPTION
Restrict ORM index key length to a maximum of 191 characters because MySQL Innodb engine limits the prefix key length to 767 bytes i.e. 191 characters.

Refer: [https://dev.mysql.com/doc/refman/5.6/en/innodb-restrictions.html](https://dev.mysql.com/doc/refman/5.6/en/innodb-restrictions.html)