### PR TITLE
Quote key columns

### DIFF
--- a/src/Entity/DoctrineMaps/CodeFoundation.FlowConfig.Entity.ConfigItem.orm.xml
+++ b/src/Entity/DoctrineMaps/CodeFoundation.FlowConfig.Entity.ConfigItem.orm.xml
@@ -15,7 +15,7 @@
 
             Refer https://dev.mysql.com/doc/refman/5.6/en/innodb-restrictions.html
         -->
-        <id name="key" type="string" length="64"><generator strategy="NONE"/></id>
+        <id name="key" column="`key`" type="string" length="64"><generator strategy="NONE"/></id>
         <field name="value" column="value" type="string" nullable="true" unique="false" />
 
     </entity>

--- a/src/Entity/DoctrineMaps/CodeFoundation.FlowConfig.Entity.EntityConfigItem.orm.xml
+++ b/src/Entity/DoctrineMaps/CodeFoundation.FlowConfig.Entity.EntityConfigItem.orm.xml
@@ -15,7 +15,7 @@
 
             Refer https://dev.mysql.com/doc/refman/5.6/en/innodb-restrictions.html
         -->
-        <id name="key" column="key" type="string" length="64"><generator strategy="NONE"/></id>
+        <id name="key" column="`key`" type="string" length="64"><generator strategy="NONE"/></id>
         <id name="entityType" column="entity_type" type="string" length="191"><generator strategy="NONE"/></id>
         <id name="entityId" column="entity_id" type="string" length="64"><generator strategy="NONE"/></id>
         <field name="value" column="value" type="string" nullable="true" unique="false" />


### PR DESCRIPTION
In MySQL, using a column called key requires the generated SQL to be quoted, which in Doctrine 2.0 isnt done automatically.